### PR TITLE
feat: add objective and key result doctypes

### DIFF
--- a/hrms/hr/doctype/key_result/key_result.js
+++ b/hrms/hr/doctype/key_result/key_result.js
@@ -1,0 +1,4 @@
+frappe.ui.form.on('Key Result', {
+    // refresh: function(frm) {
+    // }
+});

--- a/hrms/hr/doctype/key_result/key_result.json
+++ b/hrms/hr/doctype/key_result/key_result.json
@@ -1,0 +1,108 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:key_result",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "key_result",
+  "objective",
+  "metric",
+  "target",
+  "current_value",
+  "progress",
+  "weightage"
+ ],
+ "fields": [
+  {
+   "fieldname": "key_result",
+   "fieldtype": "Data",
+   "label": "Key Result",
+   "reqd": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "objective",
+   "fieldtype": "Link",
+   "label": "Objective",
+   "options": "Objective",
+   "reqd": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "metric",
+   "fieldtype": "Data",
+   "label": "Metric",
+   "reqd": 1
+  },
+  {
+   "fieldname": "target",
+   "fieldtype": "Float",
+   "label": "Target"
+  },
+  {
+   "fieldname": "current_value",
+   "fieldtype": "Float",
+   "label": "Current Value"
+  },
+  {
+   "fieldname": "progress",
+   "fieldtype": "Percent",
+   "label": "Progress",
+   "read_only": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "weightage",
+   "fieldtype": "Float",
+   "label": "Weightage"
+  }
+ ],
+ "module": "HR",
+ "name": "Key Result",
+ "permissions": [
+  {
+   "role": "System Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "report": 1,
+   "export": 1,
+   "share": 1
+  },
+  {
+   "role": "HR Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "report": 1,
+   "export": 1,
+   "share": 1
+  },
+  {
+   "role": "HR User",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "report": 1,
+   "share": 1
+  },
+  {
+   "role": "Employee",
+   "read": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/hr/doctype/key_result/key_result.py
+++ b/hrms/hr/doctype/key_result/key_result.py
@@ -1,0 +1,6 @@
+import frappe
+from frappe.model.document import Document
+
+
+class KeyResult(Document):
+    pass

--- a/hrms/hr/doctype/objective/objective.js
+++ b/hrms/hr/doctype/objective/objective.js
@@ -1,0 +1,4 @@
+frappe.ui.form.on('Objective', {
+    // refresh: function(frm) {
+    // }
+});

--- a/hrms/hr/doctype/objective/objective.json
+++ b/hrms/hr/doctype/objective/objective.json
@@ -1,0 +1,113 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:objective_name",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "objective_name",
+  "owner_type",
+  "owner",
+  "start_date",
+  "end_date",
+  "status",
+  "progress"
+ ],
+ "fields": [
+  {
+   "fieldname": "objective_name",
+   "fieldtype": "Data",
+   "label": "Objective Name",
+   "reqd": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "owner_type",
+   "fieldtype": "Select",
+   "label": "Owner Type",
+   "options": "\nEmployee\nDepartment",
+   "reqd": 1
+  },
+  {
+   "fieldname": "owner",
+   "fieldtype": "Dynamic Link",
+   "label": "Owner",
+   "options": "owner_type",
+   "reqd": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "label": "Start Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "label": "End Date"
+  },
+  {
+   "default": "Not Started",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "\nNot Started\nIn Progress\nCompleted\nCancelled"
+  },
+  {
+   "fieldname": "progress",
+   "fieldtype": "Percent",
+   "label": "Progress",
+   "read_only": 1,
+   "in_list_view": 1
+  }
+ ],
+ "module": "HR",
+ "name": "Objective",
+ "permissions": [
+  {
+   "role": "System Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "report": 1,
+   "export": 1,
+   "share": 1
+  },
+  {
+   "role": "HR Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "report": 1,
+   "export": 1,
+   "share": 1
+  },
+  {
+   "role": "HR User",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "report": 1,
+   "share": 1
+  },
+  {
+   "role": "Employee",
+   "read": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hrms/hr/doctype/objective/objective.py
+++ b/hrms/hr/doctype/objective/objective.py
@@ -1,0 +1,6 @@
+import frappe
+from frappe.model.document import Document
+
+
+class Objective(Document):
+    pass

--- a/hrms/hr/workspace/performance/performance.json
+++ b/hrms/hr/workspace/performance/performance.json
@@ -158,6 +158,34 @@
   {
    "hidden": 0,
    "is_query_report": 0,
+   "label": "Objectives & Key Results",
+   "link_count": 2,
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Objective",
+   "link_count": 0,
+   "link_to": "Objective",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Key Result",
+   "link_count": 0,
+   "link_to": "Key Result",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
    "label": "Reports",
    "link_count": 1,
    "onboard": 0,
@@ -207,6 +235,20 @@
    "doc_view": "List",
    "label": "Goal",
    "link_to": "Goal",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Objective",
+   "link_to": "Objective",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Key Result",
+   "link_to": "Key Result",
    "type": "DocType"
   }
  ],


### PR DESCRIPTION
## Summary
- add Objective DocType for tracking company objectives
- add Key Result DocType linked to objectives
- expose OKR doctypes in Performance workspace

## Testing
- `pre-commit run --files hrms/hr/doctype/objective/objective.py hrms/hr/doctype/objective/objective.js hrms/hr/doctype/objective/objective.json hrms/hr/doctype/key_result/key_result.py hrms/hr/doctype/key_result/key_result.js hrms/hr/doctype/key_result/key_result.json hrms/hr/workspace/performance/performance.json` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_688e458cf0e883249de42159114a2188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "Objective" and "Key Result" modules in the HR section, allowing users to define objectives and track associated key results.
  * Added fields for tracking progress, ownership, targets, and status for objectives and key results.
  * Enabled quick entry and list view enhancements for easier management.
  * Updated the Performance workspace to provide direct access and shortcuts to the new modules.

* **Permissions**
  * Configured role-based access, granting read-only access to employees and broader permissions to HR roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->